### PR TITLE
Fix polymorphism

### DIFF
--- a/src/main/java/com/bookstore/BookstoreApplication.java
+++ b/src/main/java/com/bookstore/BookstoreApplication.java
@@ -5,10 +5,12 @@ import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.annotations.OpenAPI31;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPI31
 @OpenAPIDefinition(
     info = @Info(
         title = "Book Store API",

--- a/src/main/java/com/bookstore/Models.java
+++ b/src/main/java/com/bookstore/Models.java
@@ -2,39 +2,59 @@ package com.bookstore;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.Arrays;
 
 public class Models {
 
-    @Schema(description = "Represents a publication in the store", 
-        oneOf = {Book.class, Magazine.class})
+    @Schema(description = "Represents a publication in the store", type="object", discriminatorMapping = {
+        @DiscriminatorMapping(value = "Book", schema = Book.class),
+        @DiscriminatorMapping(value = "Magazine", schema = Magazine.class)
+    }, discriminatorProperty = "type", enumAsRef = true)
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = Book.class, name = "BOOK"),
-        @JsonSubTypes.Type(value = Magazine.class, name = "MAGAZINE")
+        @JsonSubTypes.Type(value = Book.class, name = "Book"),
+        @JsonSubTypes.Type(value = Magazine.class, name = "Magazine")
     })
     public static abstract class Publication {
-        @Schema(description = "Unique identifier of the publication", example = "123e4567-e89b-12d3-a456-426614174000")
+        @Schema(description = "Unique identifier of the publication", example = "123e4567-e89b-12d3-a456-426614174000", nullable = true)
         private String id;
 
-        @Schema(description = "Title of the publication", example = "Spring Boot in Action")
+        @Schema(description = "Title of the publication", example = "Spring Boot in Action", nullable = true)
         private String title;
 
-        @Schema(description = "Publication date", example = "2023-06-15")
+        @Schema(description = "Publication date", example = "2023-06-15", nullable = true)
         private String publishDate;
 
-        @Schema(description = "Price in USD", example = "39.99")
+        @Schema(description = "Price in USD", example = "39.99", nullable = true)
         private float price;
+
+        @Schema(description = "Type of the publication", example = "Book", allowableValues = {"Book", "Magazine"})
+        private String type;
 
         // Constructors, getters, and setters
         public Publication() {}
 
-        public Publication(String id, String title, String publishDate, float price) {
+        public Publication(String id, String title, String publishDate, float price, String type) {
+
+            // Validate the type
+            // We don't use an Enum, because swagger-core doesn't allow subtypes to override the enum and limit the values per subtype
+            List<String> validTypes = Arrays.asList("Book", "Magazine");
+
+            if (!validTypes.contains(type)) {
+                throw new IllegalArgumentException("Invalid type: " + type);
+            }
+
             this.id = id;
             this.title = title;
             this.publishDate = publishDate;
             this.price = price;
+            this.type = type;
         }
 
         // Getters and setters
@@ -46,21 +66,27 @@ public class Models {
         public void setPublishDate(String publishDate) { this.publishDate = publishDate; }
         public float getPrice() { return price; }
         public void setPrice(float price) { this.price = price; }
+        public String getType() { return type; }
+        public void setType(String type) { this.type = type; }
     }
 
-    @Schema(description = "Represents a book in the store")
+    @Schema(description = "Represents a book in the store", allOf = {Publication.class})
+    @JsonTypeName("Book")
     public static class Book extends Publication {
-        @Schema(description = "Author of the book", example = "Craig Walls")
+        @Schema(description = "Author of the book", example = "Craig Walls", nullable = true)
         private String author;
 
-        @Schema(description = "ISBN of the book", example = "978-1617292545")
+        @Schema(description = "ISBN of the book", example = "978-1617292545", nullable = true)
         private String isbn;
+
+        @Schema(description = "Type of the publication", example = "Book", defaultValue = "Book", allowableValues = {"Book"}, requiredMode = Schema.RequiredMode.REQUIRED, accessMode = Schema.AccessMode.READ_ONLY)
+        private final String type = "Book";
 
         // Constructors
         public Book() {}
 
         public Book(String id, String title, String publishDate, float price, String author, String isbn) {
-            super(id, title, publishDate, price);
+            super(id, title, publishDate, price, "Book");
             this.author = author;
             this.isbn = isbn;
         }
@@ -72,19 +98,23 @@ public class Models {
         public void setIsbn(String isbn) { this.isbn = isbn; }
     }
 
-    @Schema(description = "Represents a magazine in the store")
+    @Schema(description = "Represents a magazine in the store", allOf = {Publication.class})
+    @JsonTypeName("Magazine")
     public static class Magazine extends Publication {
-        @Schema(description = "Issue number of the magazine", example = "42")
+        @Schema(description = "Issue number of the magazine", example = "42", nullable = true)
         private int issueNumber;
 
-        @Schema(description = "Publisher of the magazine", example = "National Geographic Society")
+        @Schema(description = "Publisher of the magazine", example = "National Geographic Society", nullable = true)
         private String publisher;
+
+        @Schema(description = "Type of the publication", example = "Magazine", defaultValue = "Magazine", allowableValues = {"Magazine"}, requiredMode = Schema.RequiredMode.REQUIRED, accessMode = Schema.AccessMode.READ_ONLY)
+        private final String type = "Magazine";
 
         // Constructors
         public Magazine() {}
 
         public Magazine(String id, String title, String publishDate, float price, int issueNumber, String publisher) {
-            super(id, title, publishDate, price);
+            super(id, title, publishDate, price, "Magazine");
             this.issueNumber = issueNumber;
             this.publisher = publisher;
         }
@@ -96,15 +126,21 @@ public class Models {
         public void setPublisher(String publisher) { this.publisher = publisher; }
     }
 
+    @Schema(description = "Represents an item in a list of publications", oneOf = {Book.class, Magazine.class}, allOf = {Publication.class}, discriminatorProperty = "type", discriminatorMapping = {
+        @DiscriminatorMapping(value = "Book", schema = Book.class),
+        @DiscriminatorMapping(value = "Magazine", schema = Magazine.class)
+    })
+    public final class PublicationListItem {}
+
     @Schema(description = "Represents an order for publications")
     public static class Order {
         @Schema(description = "Unique identifier for the order", example = "ord-123456")
         private String id;
 
-        @Schema(description = "Customer who placed the order", example = "cust-789012")
+        @Schema(description = "Customer who placed the order", example = "cust-789012", nullable = true)
         private String customerId;
 
-        @Schema(description = "List of publications in the order")
+        @ArraySchema(minItems = 1, schema = @Schema(implementation = PublicationListItem.class), arraySchema = @Schema(description = "List of items in the order"))
         private List<Publication> items;
 
         @Schema(description = "Total price of the order", example = "89.97")

--- a/src/main/java/com/bookstore/OrdersController.java
+++ b/src/main/java/com/bookstore/OrdersController.java
@@ -27,7 +27,7 @@ public class OrdersController {
     @Operation(summary = "Create a new order", description = "Create a new order for publications")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Order created successfully",
-                    content = @Content(schema = @Schema(implementation = Order.class))),
+                    content = @Content(schema = @Schema(implementation = Order.class), mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "Invalid input",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })

--- a/src/main/java/com/bookstore/OrdersController.java
+++ b/src/main/java/com/bookstore/OrdersController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -78,7 +79,7 @@ public class OrdersController {
     @Operation(summary = "List all orders", description = "Get a list of all orders in the system")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successful operation",
-                    content = @Content(schema = @Schema(implementation = Order.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = Order.class))))
     })
     @GetMapping
     public ResponseEntity<List<Order>> listOrders() {

--- a/src/main/java/com/bookstore/OrdersController.java
+++ b/src/main/java/com/bookstore/OrdersController.java
@@ -48,7 +48,7 @@ public class OrdersController {
 
         // Calculate total price
         float totalPrice = order.getItems().stream()
-            .map(Publication::getPrice)
+            .map(item -> item.getPrice())
             .reduce(0f, Float::sum);
         order.setTotalPrice(totalPrice);
 
@@ -89,7 +89,7 @@ public class OrdersController {
     @Operation(summary = "Update order status", description = "Update the status of an existing order")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Order status updated successfully",
-                    content = @Content(schema = @Schema(implementation = Order.class))),
+                    content = @Content(schema = @Schema(implementation = Order.class), mediaType = "application/json")),
         @ApiResponse(responseCode = "404", description = "Order not found",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "400", description = "Invalid status",

--- a/src/main/java/com/bookstore/PublicationsController.java
+++ b/src/main/java/com/bookstore/PublicationsController.java
@@ -37,7 +37,7 @@ public class PublicationsController {
     @Operation(summary = "Get a publication by ID", description = "Retrieves a publication's details by its unique identifier")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successful operation",
-                     content = @Content(schema = @Schema(implementation = Publication.class))),
+                     content = @Content(schema = @Schema(oneOf = {Book.class, Magazine.class}))),
         @ApiResponse(responseCode = "404", description = "Publication not found",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
@@ -52,10 +52,11 @@ public class PublicationsController {
         }
     }
 
-    @Operation(summary = "Create a new publication", description = "Add a new publication to the store")
+    @Operation(summary = "Create a new publication", description = "Add a new publication to the store", requestBody = 
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(oneOf = {Book.class, Magazine.class}))))
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successful operation",
-                     content = @Content(schema = @Schema(implementation = Publication.class))),
+                     content = @Content(schema = @Schema(oneOf = {Book.class, Magazine.class}))),
         @ApiResponse(responseCode = "400", description = "Invalid input",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })

--- a/src/main/java/com/bookstore/PublicationsController.java
+++ b/src/main/java/com/bookstore/PublicationsController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +24,7 @@ public class PublicationsController {
     @Operation(summary = "List all publications", description = "Get a list of all publications in the store")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successful operation",
-                     content = @Content(schema = @Schema(implementation = Publication.class)))
+                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = PublicationListItem.class)))),
     })
     @GetMapping
     public ResponseEntity<List<Publication>> listPublications() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,7 @@ spring.application.name=bookstore-api
 # Specify the path of the OpenAPI documentation
 springdoc.api-docs.path=/api-docs
 
+springdoc.api-docs.version=OPENAPI_3_1
+
 # Specify the path of the Swagger UI
 springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## General updates:

1. Use OpenAPI 3.1 because it is better supported by Speakeasy

## Models updates:

1. Use `ArraySchema` for Order.items and create proxy class `PublicationListItem`.
2. Remove oneOf from base class `Publication` schema decorator because it emits invalid OpenAPI.
3. Set optional properties as `nullable` (not sure this is strictly necessary).
4. Add `type` property to use for differentiator (Note: we don't use an Enum, because `io.swagger` doesn't allow us to override the Enum in subclasses. We need to limit the choices in subclasses. Using `allowableValues` works.
5. Add `requiredMode = Schema.RequiredMode.REQUIRED, accessMode = Schema.AccessMode.READ_ONLY` to subclass `type` property (not sure this is necessary).

## OrdersController updates:

1. Use each subclass' `getType` method (not sure this is strictly necessary).
2. Add `mediaType` to `Content` annotations. I think we should do this for all content annotations.

## PublicationsController updates:

1. Use oneOf in requests and responses to include oneOf in the OpenAPI document - If we don't do this, there is no strong typing per subtype in the OpenAPI document and resulting SDK.